### PR TITLE
Language Server File Operations

### DIFF
--- a/cli/src/test/kotlin/tools/samt/cli/ASTPrinterTest.kt
+++ b/cli/src/test/kotlin/tools/samt/cli/ASTPrinterTest.kt
@@ -31,11 +31,19 @@ class ASTPrinterTest {
             @Description("This is a service")
             service MyService {
               testmethod(foo: A): B
+              oneway testmethod2(foo: A)
             }
 
             provide MyEndpoint {
               implements MyService
-              transport HTTP
+              transport HTTP {
+                operations: {
+                    MyService: {
+                        testmethod: "POST /testmethod",
+                        testmethod2: "POST /testmethod2"
+                    }
+                }
+              }
             }
 
             consume MyEndpoint {
@@ -105,22 +113,41 @@ class ASTPrinterTest {
             │ │ │   └─IdentifierNode A <17:19>
             │ │ └─BundleIdentifierNode B <17:23>
             │ │   └─IdentifierNode B <17:23>
+            │ ├─OnewayOperationNode <18:3>
+            │ │ ├─IdentifierNode testmethod2 <18:10>
+            │ │ └─OperationParameterNode <18:22>
+            │ │   ├─IdentifierNode foo <18:22>
+            │ │   └─BundleIdentifierNode A <18:27>
+            │ │     └─IdentifierNode A <18:27>
             │ └─AnnotationNode <15:1>
             │   ├─IdentifierNode Description <15:2>
             │   └─StringNode "This is a service" <15:14>
-            ├─ProviderDeclarationNode <20:1>
-            │ ├─IdentifierNode MyEndpoint <20:9>
-            │ ├─ProviderImplementsNode <21:3>
-            │ │ └─BundleIdentifierNode MyService <21:14>
-            │ │   └─IdentifierNode MyService <21:14>
-            │ └─ProviderTransportNode <22:3>
-            │   └─IdentifierNode HTTP <22:13>
-            └─ConsumerDeclarationNode <25:1>
-              ├─BundleIdentifierNode MyEndpoint <25:9>
-              │ └─IdentifierNode MyEndpoint <25:9>
-              └─ConsumerUsesNode <26:3>
-                └─BundleIdentifierNode MyService <26:8>
-                  └─IdentifierNode MyService <26:8>
+            ├─ProviderDeclarationNode <21:1>
+            │ ├─IdentifierNode MyEndpoint <21:9>
+            │ ├─ProviderImplementsNode <22:3>
+            │ │ └─BundleIdentifierNode MyService <22:14>
+            │ │   └─IdentifierNode MyService <22:14>
+            │ └─ProviderTransportNode <23:3>
+            │   ├─IdentifierNode HTTP <23:13>
+            │   └─ObjectNode <23:18>
+            │     └─ObjectFieldNode <24:5>
+            │       ├─IdentifierNode operations <24:5>
+            │       └─ObjectNode <24:17>
+            │         └─ObjectFieldNode <25:9>
+            │           ├─IdentifierNode MyService <25:9>
+            │           └─ObjectNode <25:20>
+            │             ├─ObjectFieldNode <26:13>
+            │             │ ├─IdentifierNode testmethod <26:13>
+            │             │ └─StringNode "POST /testmethod" <26:25>
+            │             └─ObjectFieldNode <27:13>
+            │               ├─IdentifierNode testmethod2 <27:13>
+            │               └─StringNode "POST /testmethod2" <27:26>
+            └─ConsumerDeclarationNode <33:1>
+              ├─BundleIdentifierNode MyEndpoint <33:9>
+              │ └─IdentifierNode MyEndpoint <33:9>
+              └─ConsumerUsesNode <34:3>
+                └─BundleIdentifierNode MyService <34:8>
+                  └─IdentifierNode MyService <34:8>
         """.trimIndent().trim(), dumpWithoutColorCodes.trimIndent().trim())
     }
 

--- a/cli/src/test/kotlin/tools/samt/cli/TypePrinterTest.kt
+++ b/cli/src/test/kotlin/tools/samt/cli/TypePrinterTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertFalse
 
 class TypePrinterTest {
     @Test
-    fun `correctly formats an AST dump`() {
+    fun `correctly formats a type dump`() {
         val stuffPackage = parse("""
             package test.stuff
 
@@ -33,6 +33,8 @@ class TypePrinterTest {
               implements MyService
               transport HTTP
             }
+            
+            typealias F = E
         """.trimIndent())
         val consumerPackage = parse("""
             package test.other.company
@@ -57,6 +59,7 @@ class TypePrinterTest {
               ├─stuff
               │  enum E
               │  record A
+              │  typealias F = E
               │  service MyService
               │  provider MyEndpoint
               └─other

--- a/language-server/src/main/kotlin/tools/samt/ls/FileInfo.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/FileInfo.kt
@@ -7,11 +7,14 @@ import tools.samt.lexer.Lexer
 import tools.samt.lexer.Token
 import tools.samt.parser.FileNode
 import tools.samt.parser.Parser
+import java.net.URI
+import kotlin.io.path.readText
+import kotlin.io.path.toPath
 
 class FileInfo(
     val diagnosticContext: DiagnosticContext,
     val sourceFile: SourceFile,
-    @Suppress("unused") val tokens: List<Token>,
+    val tokens: List<Token>,
     val fileNode: FileNode? = null,
 )
 
@@ -32,4 +35,9 @@ fun parseFile(sourceFile: SourceFile): FileInfo {
     }
 
     return FileInfo(diagnosticContext, sourceFile, tokens, fileNode)
+}
+
+fun readAndParseFile(uri: URI): FileInfo {
+    val sourceFile = SourceFile(uri, uri.toPath().readText())
+    return parseFile(sourceFile)
 }

--- a/language-server/src/main/kotlin/tools/samt/ls/FileInfo.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/FileInfo.kt
@@ -18,6 +18,8 @@ class FileInfo(
     val fileNode: FileNode? = null,
 )
 
+val FileInfo.path get() = sourceFile.path
+
 fun parseFile(sourceFile: SourceFile): FileInfo {
     val diagnosticContext = DiagnosticContext(sourceFile)
 

--- a/language-server/src/main/kotlin/tools/samt/ls/FileInfo.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/FileInfo.kt
@@ -12,10 +12,10 @@ import kotlin.io.path.readText
 import kotlin.io.path.toPath
 
 class FileInfo(
-    val diagnosticContext: DiagnosticContext,
-    val sourceFile: SourceFile,
-    val tokens: List<Token>,
-    val fileNode: FileNode? = null,
+        val diagnosticContext: DiagnosticContext,
+        val sourceFile: SourceFile,
+        val tokens: List<Token> = emptyList(),
+        val fileNode: FileNode? = null,
 )
 
 val FileInfo.path get() = sourceFile.path
@@ -23,7 +23,11 @@ val FileInfo.path get() = sourceFile.path
 fun parseFile(sourceFile: SourceFile): FileInfo {
     val diagnosticContext = DiagnosticContext(sourceFile)
 
-    val tokens = Lexer.scan(sourceFile.content.reader(), diagnosticContext).toList()
+    val tokens = try {
+        Lexer.scan(sourceFile.content.reader(), diagnosticContext).toList()
+    } catch (e: DiagnosticException) {
+        return FileInfo(diagnosticContext, sourceFile)
+    }
 
     if (diagnosticContext.hasErrors()) {
         return FileInfo(diagnosticContext, sourceFile, tokens)

--- a/language-server/src/main/kotlin/tools/samt/ls/FileInfo.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/FileInfo.kt
@@ -19,6 +19,7 @@ class FileInfo(
 )
 
 val FileInfo.path get() = sourceFile.path
+val FileInfo.content get() = sourceFile.content
 
 fun parseFile(sourceFile: SourceFile): FileInfo {
     val diagnosticContext = DiagnosticContext(sourceFile)

--- a/language-server/src/main/kotlin/tools/samt/ls/Mapping.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/Mapping.kt
@@ -9,11 +9,7 @@ fun DiagnosticMessage.toDiagnostic(): Diagnostic? {
     val diagnostic = Diagnostic()
     val primaryHighlight = this.highlights.firstOrNull() ?: return null
     diagnostic.range = primaryHighlight.location.toRange()
-    diagnostic.severity = when (severity) {
-        DiagnosticSeverity.Error -> org.eclipse.lsp4j.DiagnosticSeverity.Error
-        DiagnosticSeverity.Warning -> org.eclipse.lsp4j.DiagnosticSeverity.Warning
-        DiagnosticSeverity.Info -> org.eclipse.lsp4j.DiagnosticSeverity.Information
-    }
+    diagnostic.severity = severity.toLspSeverity()
     diagnostic.source = "samt"
     diagnostic.message = message
     diagnostic.relatedInformation = highlights.filter { it.message != null }.map {
@@ -25,9 +21,13 @@ fun DiagnosticMessage.toDiagnostic(): Diagnostic? {
     return diagnostic
 }
 
-fun SamtLocation.toRange(): Range {
-    return Range(
-        Position(start.row, start.col),
-        Position(end.row, end.col)
-    )
+fun DiagnosticSeverity.toLspSeverity(): org.eclipse.lsp4j.DiagnosticSeverity = when (this) {
+    DiagnosticSeverity.Error -> org.eclipse.lsp4j.DiagnosticSeverity.Error
+    DiagnosticSeverity.Warning -> org.eclipse.lsp4j.DiagnosticSeverity.Warning
+    DiagnosticSeverity.Info -> org.eclipse.lsp4j.DiagnosticSeverity.Information
 }
+
+fun SamtLocation.toRange(): Range = Range(
+    Position(start.row, start.col),
+    Position(end.row, end.col)
+)

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtFolder.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtFolder.kt
@@ -8,7 +8,7 @@ import tools.samt.semantic.Package
 import tools.samt.semantic.SemanticModelBuilder
 import java.net.URI
 
-class SamtFolder (val path: URI) : Iterable<FileInfo> {
+class SamtFolder(val path: URI) : Iterable<FileInfo> {
     private val files = mutableMapOf<URI, FileInfo>()
     var globalPackage: Package? = null
         private set
@@ -48,7 +48,7 @@ class SamtFolder (val path: URI) : Iterable<FileInfo> {
     }
 
     companion object {
-        fun createFromDirectory(path: URI): SamtFolder {
+        fun fromDirectory(path: URI): SamtFolder {
             val controller = DiagnosticController(path)
             val workspace = SamtFolder(path)
             val sourceFiles = collectSamtFiles(path).readSamtSource(controller)

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtFolder.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtFolder.kt
@@ -12,7 +12,7 @@ import java.net.URI
 import java.nio.file.Path
 import kotlin.io.path.toPath
 
-class SamtWorkspace (private val parserController: DiagnosticController) : Iterable<FileInfo> {
+class SamtFolder (private val parserController: DiagnosticController) : Iterable<FileInfo> {
     private val files = mutableMapOf<URI, FileInfo>()
     var samtPackage: Package? = null
         private set
@@ -55,9 +55,9 @@ class SamtWorkspace (private val parserController: DiagnosticController) : Itera
     }
 
     companion object {
-        fun createFromDirectory(folder: URI): SamtWorkspace {
+        fun createFromDirectory(folder: URI): SamtFolder {
             val controller = DiagnosticController(folder)
-            val workspace = SamtWorkspace(controller)
+            val workspace = SamtFolder(controller)
             val sourceFiles = collectSamtFiles(folder).readSamtSource(controller)
             sourceFiles.forEach {
                 workspace.set(parseFile(it))
@@ -67,7 +67,7 @@ class SamtWorkspace (private val parserController: DiagnosticController) : Itera
     }
 }
 
-fun LanguageClient.publishWorkspaceDiagnostics(workspace: SamtWorkspace) {
+fun LanguageClient.publishWorkspaceDiagnostics(workspace: SamtFolder) {
     workspace.getAllMessages().forEach { (path, messages) ->
         publishDiagnostics(
             PublishDiagnosticsParams(
@@ -78,6 +78,6 @@ fun LanguageClient.publishWorkspaceDiagnostics(workspace: SamtWorkspace) {
     }
 }
 
-fun Map<*, SamtWorkspace>.getByFile(filePath: Path): SamtWorkspace? =
+fun Map<*, SamtFolder>.getByFile(filePath: Path): SamtFolder? =
     values.firstOrNull {  filePath.startsWith(it.workingDirectory.toPath()) }
-fun Map<*, SamtWorkspace>.getByFile(fileUri: URI): SamtWorkspace? = getByFile(fileUri.toPath())
+fun Map<*, SamtFolder>.getByFile(fileUri: URI): SamtFolder? = getByFile(fileUri.toPath())

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtLanguageServer.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtLanguageServer.kt
@@ -90,7 +90,7 @@ class SamtLanguageServer : LanguageServer, LanguageClientAware, Closeable {
     private fun buildSamtModel(params: InitializeParams) {
         val folders = params.workspaceFolders?.map { it.uri.toPathUri() }.orEmpty()
         for (folder in folders) {
-            workspace.addFolder(SamtFolder.createFromDirectory(folder))
+            workspace.addFolder(SamtFolder.fromDirectory(folder))
         }
     }
 

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtLanguageServer.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtLanguageServer.kt
@@ -83,7 +83,7 @@ class SamtLanguageServer : LanguageServer, LanguageClientAware, Closeable {
         val diagnosticController = DiagnosticController(workspacePath)
         val sourceFiles = collectSamtFiles(workspacePath).readSamtSource(diagnosticController)
         val workspace = SamtWorkspace(diagnosticController)
-        sourceFiles.asSequence().map(::parseFile).forEach(workspace::add)
+        sourceFiles.asSequence().map(::parseFile).forEach(workspace::set)
         workspace.buildSemanticModel()
         return workspace
     }

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtLanguageServer.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtLanguageServer.kt
@@ -35,7 +35,7 @@ class SamtLanguageServer : LanguageServer, LanguageClientAware, Closeable {
         }
 
     override fun initialized(params: InitializedParams) {
-        pushDiagnostics()
+        workspaces.values.forEach(client::publishWorkspaceDiagnostics)
     }
 
     override fun shutdown(): CompletableFuture<Any> = CompletableFuture.completedFuture(null)
@@ -74,16 +74,5 @@ class SamtLanguageServer : LanguageServer, LanguageClientAware, Closeable {
         sourceFiles.asSequence().map(::parseFile).forEach(workspace::add)
         workspace.buildSemanticModel()
         return workspace
-    }
-
-    private fun pushDiagnostics() {
-        workspaces.values.flatMap { workspace ->
-            workspace.getAllMessages().map { (path, messages) ->
-                PublishDiagnosticsParams(
-                    path.toString(),
-                    messages.map { it.toDiagnostic() }
-                )
-            }
-        }.forEach(client::publishDiagnostics)
     }
 }

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtLanguageServer.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtLanguageServer.kt
@@ -13,7 +13,7 @@ import kotlin.system.exitProcess
 class SamtLanguageServer : LanguageServer, LanguageClientAware, Closeable {
     private lateinit var client: LanguageClient
     private val logger = Logger.getLogger("SamtLanguageServer")
-    private val workspaces = mutableMapOf<URI, SamtWorkspace>()
+    private val workspaces = mutableMapOf<URI, SamtFolder>()
     private val textDocumentService = SamtTextDocumentService(workspaces)
     private val workspaceService = SamtWorkspaceService(workspaces)
 
@@ -93,7 +93,7 @@ class SamtLanguageServer : LanguageServer, LanguageClientAware, Closeable {
         for (folder in folders) {
             // if the folder is contained within another folder ignore it
             if (folders.any { folder != it && folder.path.startsWith(it.path) }) continue
-            workspaces[folder] = SamtWorkspace.createFromDirectory(folder)
+            workspaces[folder] = SamtFolder.createFromDirectory(folder)
         }
     }
 

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtTextDocumentService.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtTextDocumentService.kt
@@ -15,7 +15,7 @@ import java.net.URI
 import java.util.concurrent.CompletableFuture
 import java.util.logging.Logger
 
-class SamtTextDocumentService(private val workspaces: Map<URI, SamtWorkspace>) : TextDocumentService,
+class SamtTextDocumentService(private val workspaces: Map<URI, SamtFolder>) : TextDocumentService,
     LanguageClientAware {
     private lateinit var client: LanguageClient
     private val logger = Logger.getLogger("SamtTextDocumentService")

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtTextDocumentService.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtTextDocumentService.kt
@@ -120,7 +120,7 @@ class SamtTextDocumentService(private val workspace: SamtWorkspace) : TextDocume
 
             val tokens: List<Token> = fileInfo.tokens
             val fileNode: FileNode = fileInfo.fileNode ?: return@supplyAsync SemanticTokens(emptyList())
-            val globalPackage: Package = workspace.getFolderSnapshot(path)?.globalPackage ?: return@supplyAsync SemanticTokens(emptyList())
+            val globalPackage: Package = workspace.getRootPackage(path) ?: return@supplyAsync SemanticTokens(emptyList())
             val samtPackage = globalPackage.resolveSubPackage(fileNode.packageDeclaration.name)
 
             val semanticTokens = SamtSemanticTokens.analyze(fileNode, samtPackage)

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtTextDocumentService.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtTextDocumentService.kt
@@ -22,6 +22,13 @@ class SamtTextDocumentService(private val workspaces: Map<URI, SamtWorkspace>) :
 
     override fun didOpen(params: DidOpenTextDocumentParams) {
         logger.info("Opened document ${params.textDocument.uri}")
+        val path = params.textDocument.uri.toPathUri()
+        val workspace = workspaces.getByFile(path) ?: return
+        val text = params.textDocument.text
+
+        workspace.set(parseFile(SourceFile(path, text)))
+        workspace.buildSemanticModel()
+        client.publishWorkspaceDiagnostics(workspace)
     }
 
     override fun didChange(params: DidChangeTextDocumentParams) {
@@ -41,6 +48,7 @@ class SamtTextDocumentService(private val workspaces: Map<URI, SamtWorkspace>) :
         logger.info("Closed document ${params.textDocument.uri}")
         val path = params.textDocument.uri.toPathUri()
         val workspace = workspaces.getByFile(path) ?: return
+
         workspace.set(readAndParseFile(path))
         workspace.buildSemanticModel()
         client.publishWorkspaceDiagnostics(workspace)

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtTextDocumentService.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtTextDocumentService.kt
@@ -32,7 +32,7 @@ class SamtTextDocumentService(private val workspaces: Map<URI, SamtWorkspace>) :
         val fileInfo = parseFile(SourceFile(path, newText))
         val workspace = workspaces.getByFile(path) ?: return
 
-        workspace.add(fileInfo)
+        workspace.set(fileInfo)
         workspace.buildSemanticModel()
         client.publishWorkspaceDiagnostics(workspace)
     }

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtTextDocumentService.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtTextDocumentService.kt
@@ -39,6 +39,11 @@ class SamtTextDocumentService(private val workspaces: Map<URI, SamtWorkspace>) :
 
     override fun didClose(params: DidCloseTextDocumentParams) {
         logger.info("Closed document ${params.textDocument.uri}")
+        val path = params.textDocument.uri.toPathUri()
+        val workspace = workspaces.getByFile(path) ?: return
+        workspace.set(readAndParseFile(path))
+        workspace.buildSemanticModel()
+        client.publishWorkspaceDiagnostics(workspace)
     }
 
     override fun didSave(params: DidSaveTextDocumentParams) {

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
@@ -32,6 +32,11 @@ class SamtWorkspace(private val parserController: DiagnosticController) : Iterab
 
     operator fun contains(path: URI) = path in files
 
+    fun getFilesIn(directoryPath: URI): List<URI> {
+        val path = directoryPath.toPath()
+        return files.keys.filter { it.toPath().startsWith(path) }
+    }
+
     fun buildSemanticModel() {
         semanticController = DiagnosticController(parserController.workingDirectory)
         samtPackage = SemanticModelBuilder.build(mapNotNull { it.fileNode }, semanticController)

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
@@ -17,7 +17,7 @@ class SamtWorkspace(private val parserController: DiagnosticController) : Iterab
     private var semanticController: DiagnosticController =
         DiagnosticController(parserController.workingDirectory)
 
-    fun add(fileInfo: FileInfo) {
+    fun set(fileInfo: FileInfo) {
         files[fileInfo.sourceFile.path] = fileInfo
     }
 

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
@@ -16,6 +16,7 @@ class SamtWorkspace(private val parserController: DiagnosticController) : Iterab
         private set
     private var semanticController: DiagnosticController =
         DiagnosticController(parserController.workingDirectory)
+    val workingDirectory = parserController.workingDirectory
 
     fun set(fileInfo: FileInfo) {
         files[fileInfo.sourceFile.path] = fileInfo
@@ -58,6 +59,6 @@ fun LanguageClient.publishWorkspaceDiagnostics(workspace: SamtWorkspace) {
     }
 }
 
-fun Map<URI, SamtWorkspace>.getByFile(filePath: Path): SamtWorkspace? =
-    entries.firstOrNull { (uri) -> filePath.startsWith(uri.toPath()) }?.value
-fun Map<URI, SamtWorkspace>.getByFile(fileUri: URI): SamtWorkspace? = getByFile(fileUri.toPath())
+fun Map<*, SamtWorkspace>.getByFile(filePath: Path): SamtWorkspace? =
+    values.firstOrNull {  filePath.startsWith(it.workingDirectory.toPath()) }
+fun Map<*, SamtWorkspace>.getByFile(fileUri: URI): SamtWorkspace? = getByFile(fileUri.toPath())

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
@@ -21,6 +21,10 @@ class SamtWorkspace(private val parserController: DiagnosticController) : Iterab
         files[fileInfo.sourceFile.path] = fileInfo
     }
 
+    fun remove(fileUri: URI) {
+        files.remove(fileUri)
+    }
+
     operator fun get(path: URI): FileInfo? = files[path]
 
     override fun iterator(): Iterator<FileInfo> = files.values.iterator()

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
@@ -59,9 +59,7 @@ class SamtWorkspace {
     fun getRootPackage(path: URI): Package? = getFolder(path)?.globalPackage
 
     fun getPendingMessages(): Map<URI, List<DiagnosticMessage>> = changedFolders.flatMap { folder ->
-        folder.getAllMessages().map { (path, messages) ->
-            path to messages
-        }
+        folder.getAllMessages().toList()
     }.toMap() + removedFiles.associateWith { emptyList() }
 
     fun buildSemanticModel() {

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
@@ -1,0 +1,93 @@
+package tools.samt.ls
+
+import org.eclipse.lsp4j.PublishDiagnosticsParams
+import org.eclipse.lsp4j.services.LanguageClient
+import tools.samt.common.DiagnosticMessage
+import tools.samt.semantic.Package
+import java.net.URI
+
+class SamtWorkspace {
+    private val folders = mutableMapOf<URI, SamtFolder>()
+    private val changedFolders = mutableSetOf<SamtFolder>()
+    private val removedFiles = mutableSetOf<URI>()
+
+    fun getFolderSnapshot(path: URI): FolderSnapshot? = getFolder(path)?.let { FolderSnapshot(it.path, it.toList(), it.globalPackage) }
+
+    fun addFolder(folder: SamtFolder) {
+        val newPath = folder.path
+        // folder is contained in other folder, ignore
+        if (folders.keys.any { newPath.startsWith(it) }) {
+            return
+        }
+        // remove folders contained in new folder
+        folders.keys.removeIf { it.startsWith(newPath) }
+        folders[folder.path] = folder
+        changedFolders.add(folder)
+    }
+
+    fun removeFolder(path: URI) {
+        folders.remove(path)?.let { folder ->
+            removedFiles.addAll(folder.map { it.path })
+        }
+    }
+
+    fun getFile(path: URI): FileInfo? = getFolder(path)?.get(path)
+
+    fun setFile(file: FileInfo) {
+        val folder = getFolder(file.path) ?: return
+        folder.set(file)
+        changedFolders.add(folder)
+    }
+
+    fun removeFile(path: URI) {
+        val folder = getFolder(path) ?: return
+        folder.remove(path)
+        changedFolders.add(folder)
+        removedFiles.add(path)
+    }
+
+    fun removeDirectory(path: URI) {
+        val folder = getFolder(path)
+        val files = folder?.getFilesIn(path)?.ifEmpty { null } ?: return
+        changedFolders.add(folder)
+        for (file in files) {
+            folder.remove(file)
+            removedFiles.add(file)
+        }
+    }
+
+    fun getRootPackage(path: URI): Package? = getFolder(path)?.globalPackage
+
+    fun getPendingMessages(): Map<URI, List<DiagnosticMessage>> = changedFolders.flatMap { folder ->
+        folder.getAllMessages().map { (path, messages) ->
+            path to messages
+        }
+    }.toMap() + removedFiles.associateWith { emptyList() }
+
+    fun buildSemanticModel() {
+        changedFolders.forEach { it.buildSemanticModel() }
+    }
+
+    fun clearChanges() {
+        changedFolders.clear()
+        removedFiles.clear()
+    }
+
+    private fun getFolder(path: URI): SamtFolder? = folders[path] ?: folders.values.singleOrNull { path.startsWith(it.path) }
+}
+
+data class FolderSnapshot(val path: URI, val files: List<FileInfo>, val globalPackage: Package?)
+
+
+fun LanguageClient.updateWorkspace(workspace: SamtWorkspace) {
+    workspace.buildSemanticModel()
+    workspace.getPendingMessages().forEach { (path, messages) ->
+        publishDiagnostics(
+                PublishDiagnosticsParams(
+                        path.toString(),
+                        messages.mapNotNull { it.toDiagnostic() }
+                )
+        )
+    }
+    workspace.clearChanges()
+}

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspace.kt
@@ -34,6 +34,8 @@ class SamtWorkspace {
     fun getFile(path: URI): FileInfo? = getFolder(path)?.get(path)
 
     fun setFile(file: FileInfo) {
+        val currentFile = getFile(file.path)
+        if (file.content == currentFile?.content) return
         val folder = getFolder(file.path) ?: return
         folder.set(file)
         changedFolders.add(folder)

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspaceService.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspaceService.kt
@@ -27,7 +27,7 @@ class SamtWorkspaceService(private val workspaces: Map<URI, SamtWorkspace>) : Wo
             when (change.type) {
                 FileChangeType.Created, FileChangeType.Changed -> {
                     val sourceFile = SourceFile(uri, uri.toPath().readText())
-                    workspace.add(parseFile(sourceFile))
+                    workspace.set(parseFile(sourceFile))
                 }
                 FileChangeType.Deleted -> {
                     workspace.remove(uri)

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspaceService.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspaceService.kt
@@ -1,0 +1,47 @@
+package tools.samt.ls
+
+import org.eclipse.lsp4j.DidChangeConfigurationParams
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams
+import org.eclipse.lsp4j.FileChangeType
+import org.eclipse.lsp4j.services.LanguageClient
+import org.eclipse.lsp4j.services.LanguageClientAware
+import org.eclipse.lsp4j.services.WorkspaceService
+import tools.samt.common.SourceFile
+import java.net.URI
+import kotlin.io.path.readText
+import kotlin.io.path.toPath
+
+class SamtWorkspaceService(private val workspaces: Map<URI, SamtWorkspace>) : WorkspaceService, LanguageClientAware {
+    private lateinit var client: LanguageClient
+
+    override fun didChangeConfiguration(params: DidChangeConfigurationParams?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun didChangeWatchedFiles(params: DidChangeWatchedFilesParams) {
+        val affectedWorkspaces = mutableSetOf<SamtWorkspace>()
+        for (change in params.changes) {
+            val uri = change.uri.toPathUri()
+            val workspace = workspaces.getByFile(uri) ?: continue
+            affectedWorkspaces.add(workspace)
+            when (change.type) {
+                FileChangeType.Created, FileChangeType.Changed -> {
+                    val sourceFile = SourceFile(uri, uri.toPath().readText())
+                    workspace.add(parseFile(sourceFile))
+                }
+                FileChangeType.Deleted -> {
+                    workspace.remove(uri)
+                }
+                null -> error("Unexpected null value for change.type")
+            }
+        }
+        for (workspace in affectedWorkspaces) {
+            workspace.buildSemanticModel()
+            client.publishWorkspaceDiagnostics(workspace)
+        }
+    }
+
+    override fun connect(client: LanguageClient) {
+        this.client = client
+    }
+}

--- a/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspaceService.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/SamtWorkspaceService.kt
@@ -1,15 +1,13 @@
 package tools.samt.ls
 
-import org.eclipse.lsp4j.DidChangeConfigurationParams
-import org.eclipse.lsp4j.DidChangeWatchedFilesParams
-import org.eclipse.lsp4j.FileChangeType
+import org.eclipse.lsp4j.*
 import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.lsp4j.services.LanguageClientAware
 import org.eclipse.lsp4j.services.WorkspaceService
-import tools.samt.common.SourceFile
+import tools.samt.common.DiagnosticController
+import tools.samt.common.collectSamtFiles
+import tools.samt.common.readSamtSource
 import java.net.URI
-import kotlin.io.path.readText
-import kotlin.io.path.toPath
 
 class SamtWorkspaceService(private val workspaces: Map<URI, SamtWorkspace>) : WorkspaceService, LanguageClientAware {
     private lateinit var client: LanguageClient
@@ -18,30 +16,101 @@ class SamtWorkspaceService(private val workspaces: Map<URI, SamtWorkspace>) : Wo
         TODO("Not yet implemented")
     }
 
-    override fun didChangeWatchedFiles(params: DidChangeWatchedFilesParams) {
-        val affectedWorkspaces = mutableSetOf<SamtWorkspace>()
+    override fun didChangeWatchedFiles(params: DidChangeWatchedFilesParams) = updateWorkspaces {
         for (change in params.changes) {
             val uri = change.uri.toPathUri()
             val workspace = workspaces.getByFile(uri) ?: continue
-            affectedWorkspaces.add(workspace)
-            when (change.type) {
-                FileChangeType.Created, FileChangeType.Changed -> {
-                    val sourceFile = SourceFile(uri, uri.toPath().readText())
-                    workspace.set(parseFile(sourceFile))
+            if (change.uri.endsWith(".samt")) {
+                when (change.type) {
+                    FileChangeType.Created, FileChangeType.Changed -> workspace.set(readAndParseFile(uri))
+                    FileChangeType.Deleted -> removeFile(workspace, uri)
+                    null -> error("Unexpected null value for change.type")
                 }
-                FileChangeType.Deleted -> {
-                    workspace.remove(uri)
+
+            } else {
+                when (change.type) {
+                    FileChangeType.Created -> {
+                        val sourceFiles = collectSamtFiles(uri).readSamtSource(DiagnosticController(workspace.workingDirectory))
+                        sourceFiles.forEach {
+                            workspace.set(parseFile(it))
+                        }
+                    }
+                    FileChangeType.Changed -> {}
+                    FileChangeType.Deleted -> {
+                        workspace.getFilesIn(uri).forEach { removeFile(workspace, it) }
+                    }
+                    null -> error("Unexpected null value for change.type")
                 }
-                null -> error("Unexpected null value for change.type")
+            }
+            yield(workspace)
+        }
+    }
+
+    override fun didCreateFiles(params: CreateFilesParams) = updateWorkspaces {
+        for (file in params.files) {
+            val uri = file.uri.toPathUri()
+            val workspace = workspaces.getByFile(uri) ?: continue
+            workspace.set(readAndParseFile(uri))
+            yield(workspace)
+        }
+    }
+
+    override fun didRenameFiles(params: RenameFilesParams) = updateWorkspaces {
+        for (file in params.files) {
+            val oldUri = file.oldUri.toPathUri()
+            val newUri = file.newUri.toPathUri()
+            val oldWorkspace = workspaces.getByFile(oldUri)
+            val newWorkspace = workspaces.getByFile(newUri)
+            if (file.oldUri.endsWith(".samt")) {
+                oldWorkspace?.let {
+                    removeFile(it, oldUri)
+                    yield(it)
+                }
+                newWorkspace?.let {
+                    it.set(readAndParseFile(newUri))
+                    yield(it)
+                }
+            } else {
+                oldWorkspace?.let { workspace ->
+                    workspace.getFilesIn(oldUri).forEach { removeFile(workspace, it) }
+                    yield(workspace)
+                }
+                newWorkspace?.let { workspace ->
+                    val sourceFiles = collectSamtFiles(newUri).readSamtSource(DiagnosticController(workspace.workingDirectory))
+                    sourceFiles.forEach {
+                        workspace.set(parseFile(it))
+                    }
+                    yield(workspace)
+                }
             }
         }
-        for (workspace in affectedWorkspaces) {
-            workspace.buildSemanticModel()
-            client.publishWorkspaceDiagnostics(workspace)
+    }
+
+    override fun didDeleteFiles(params: DeleteFilesParams) = updateWorkspaces {
+        for (file in params.files) {
+            val uri = file.uri.toPathUri()
+            val workspace = workspaces.getByFile(uri) ?: continue
+            if (file.uri.endsWith(".samt")) {
+                removeFile(workspace, uri)
+            } else {
+                workspace.getFilesIn(uri).forEach { removeFile(workspace, it) }
+            }
+            yield(workspace)
         }
     }
 
     override fun connect(client: LanguageClient) {
         this.client = client
+    }
+
+    private fun updateWorkspaces(block: suspend SequenceScope<SamtWorkspace>.() -> Unit): Unit =
+        sequence(block).toSet().forEach {
+            it.buildSemanticModel()
+            client.publishWorkspaceDiagnostics(it)
+        }
+
+    private fun removeFile(workspace: SamtWorkspace, file: URI) {
+        workspace.remove(file)
+        client.publishDiagnostics(PublishDiagnosticsParams(file.toString(), emptyList()))
     }
 }

--- a/language-server/src/main/kotlin/tools/samt/ls/Uri.kt
+++ b/language-server/src/main/kotlin/tools/samt/ls/Uri.kt
@@ -3,4 +3,6 @@ package tools.samt.ls
 import java.net.URI
 import kotlin.io.path.toPath
 
-fun String.toPathUri(): URI = URI(this).toPath().toUri()
+internal fun String.toPathUri(): URI = URI(this).toPath().toUri()
+
+internal fun URI.startsWith(other: URI): Boolean = toPath().startsWith(other.toPath())

--- a/language-server/src/test/kotlin/tools/samt/ls/FileInfoTest.kt
+++ b/language-server/src/test/kotlin/tools/samt/ls/FileInfoTest.kt
@@ -1,0 +1,57 @@
+package tools.samt.ls
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import tools.samt.common.SourceFile
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FileInfoTest {
+    @Test
+    fun `parseFile conserves path`() {
+        val sourceFile = SourceFile("file:///tmp/test.samt".toPathUri(), "package foo.bar")
+        val fileInfo = parseFile(sourceFile)
+        assertEquals(sourceFile.path, fileInfo.path)
+    }
+
+    @Test
+    fun `parseFile handles fatal lexer errors`() {
+        val sourceFile = SourceFile("file:///tmp/test.samt".toPathUri(), "package foo.bar;")
+        assertDoesNotThrow {
+            val fileInfo = parseFile(sourceFile)
+            assertEquals(emptyList(), fileInfo.tokens)
+            assertNull(fileInfo.fileNode)
+            assertTrue(fileInfo.diagnosticContext.hasErrors())
+        }
+    }
+
+    @Test
+    fun `parseFile handles non fatal lexer errors`() {
+        val sourceFile = SourceFile("file:///tmp/test.samt".toPathUri(), "\"foo")
+        val fileInfo = parseFile(sourceFile)
+        assertTrue(fileInfo.tokens.isNotEmpty())
+        assertNull(fileInfo.fileNode)
+        assertTrue(fileInfo.diagnosticContext.hasErrors())
+    }
+
+    @Test
+    fun `parseFile handles fatal parser errors`() {
+        val sourceFile = SourceFile("file:///tmp/test.samt".toPathUri(), "package foo.bar record Greeter { } }")
+        assertDoesNotThrow {
+            val fileInfo = parseFile(sourceFile)
+            assertNull(fileInfo.fileNode)
+            assertTrue(fileInfo.diagnosticContext.hasErrors())
+        }
+    }
+
+    @Test
+    fun `parseFile returns tokens and AST`() {
+        val sourceFile = SourceFile("file:///tmp/test.samt".toPathUri(), "package foo.bar")
+        val fileInfo = parseFile(sourceFile)
+        assertEquals(emptyList(),  fileInfo.diagnosticContext.messages)
+        assertTrue(fileInfo.tokens.isNotEmpty())
+        assertNotNull(fileInfo.fileNode)
+    }
+}

--- a/language-server/src/test/kotlin/tools/samt/ls/MappingTest.kt
+++ b/language-server/src/test/kotlin/tools/samt/ls/MappingTest.kt
@@ -1,0 +1,91 @@
+package tools.samt.ls
+
+import org.eclipse.lsp4j.DiagnosticRelatedInformation
+import org.eclipse.lsp4j.Location
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import tools.samt.common.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import tools.samt.common.Location as SamtLocation
+
+class MappingTest {
+
+    @Test
+    fun `toDiagnostic returns null if no highlights`() {
+        val message = DiagnosticMessage(
+                DiagnosticSeverity.Error,
+                "message",
+                listOf(),
+                listOf()
+        )
+        val diagnostic = message.toDiagnostic()
+        assertNull(diagnostic)
+    }
+
+    @Test
+    fun `toDiagnostic converts to LSP diagnostic`() {
+        val location = SamtLocation(
+                SourceFile("file:///tmp/test.samt".toPathUri(), "package foo.bar\nrecord Foo {}"),
+                FileOffset(0, 0, 2),
+                FileOffset(10, 1, 3)
+        )
+        val highlight = DiagnosticHighlight(
+                "highlight message",
+                location,
+                "suggestion",
+                false
+        )
+        val message = DiagnosticMessage(
+                DiagnosticSeverity.Error,
+                "message",
+                listOf(highlight),
+                listOf()
+        )
+        val diagnostic = message.toDiagnostic()
+        assertNotNull(diagnostic)
+        assertEquals("message", diagnostic.message)
+        assertEquals(org.eclipse.lsp4j.DiagnosticSeverity.Error, diagnostic.severity)
+        assertEquals("samt", diagnostic.source)
+        assertEquals(Range(
+                Position(0, 2),
+                Position(1, 3)
+        ), diagnostic.range)
+        assertEquals(listOf(DiagnosticRelatedInformation(
+                Location("file:///tmp/test.samt", Range(
+                        Position(0, 2),
+                        Position(1, 3)
+                )),
+                "highlight message"
+        )), diagnostic.relatedInformation)
+    }
+
+    @Test
+    fun `toLspSeverity converts to LSP severity`() {
+        val expected = mapOf(
+                DiagnosticSeverity.Error to org.eclipse.lsp4j.DiagnosticSeverity.Error,
+                DiagnosticSeverity.Warning to org.eclipse.lsp4j.DiagnosticSeverity.Warning,
+                DiagnosticSeverity.Info to org.eclipse.lsp4j.DiagnosticSeverity.Information
+        )
+        assertEquals(expected, DiagnosticSeverity.values().associateWith { it.toLspSeverity() })
+    }
+
+    @Test
+    fun `toRange converts to LSP range`() {
+        val sourceFile = SourceFile("file:///tmp/test.samt".toPathUri(), "package foo.bar\nrecord Foo {}")
+        val start = FileOffset(0, 0, 2)
+        val end = FileOffset(10, 1, 3)
+        val location = SamtLocation(
+                sourceFile,
+                start,
+                end
+        )
+        val range = location.toRange()
+        assertEquals(Range(
+                Position(0, 2),
+                Position(1, 3)
+        ), range)
+    }
+}

--- a/language-server/src/test/kotlin/tools/samt/ls/MappingTest.kt
+++ b/language-server/src/test/kotlin/tools/samt/ls/MappingTest.kt
@@ -54,7 +54,7 @@ class MappingTest {
                 Position(1, 3)
         ), diagnostic.range)
         assertEquals(listOf(DiagnosticRelatedInformation(
-                Location("file:///tmp/test.samt", Range(
+                Location("file:///tmp/test.samt".toPathUri().toString(), Range(
                         Position(0, 2),
                         Position(1, 3)
                 )),

--- a/language-server/src/test/kotlin/tools/samt/ls/SamtFolderTest.kt
+++ b/language-server/src/test/kotlin/tools/samt/ls/SamtFolderTest.kt
@@ -47,7 +47,7 @@ class SamtFolderTest {
         val workspace = SamtFolder("file:///tmp/test".toPathUri())
         val uri1 = "file:///tmp/test/record.samt".toPathUri()
         val uri2 = "file:///tmp/test/service.samt".toPathUri()
-        val fileInfo1 = parseFile(SourceFile(uri1, "package foo.bar recrd Foo { "))
+        val fileInfo1 = parseFile(SourceFile(uri1, "package foo.bar record Foo { "))
         val fileInfo2 = parseFile(SourceFile(uri2, "package foo.bar service FooService { getService(): Foo }"))
         workspace.set(fileInfo1)
         workspace.set(fileInfo2)

--- a/language-server/src/test/kotlin/tools/samt/ls/SamtFolderTest.kt
+++ b/language-server/src/test/kotlin/tools/samt/ls/SamtFolderTest.kt
@@ -5,7 +5,7 @@ import tools.samt.common.SourceFile
 import java.net.URI
 import kotlin.test.*
 
-class SamtWorkspaceTest {
+class SamtFolderTest {
     @Test
     fun `getByFile returns correct workspace`() {
         val workspaces = createWorkspaces()
@@ -23,7 +23,7 @@ class SamtWorkspaceTest {
 
     @Test
     fun `file can be retrieved with URI after set`() {
-        val workspace = SamtWorkspace(DiagnosticController("file:///tmp/test".toPathUri()))
+        val workspace = SamtFolder(DiagnosticController("file:///tmp/test".toPathUri()))
         val uri = "file:///tmp/test/model.samt".toPathUri()
         val fileInfo = parseFile(SourceFile(uri, "package foo.bar"))
         workspace.set(fileInfo)
@@ -34,7 +34,7 @@ class SamtWorkspaceTest {
 
     @Test
     fun `file cannot be retrieved after removal`() {
-        val workspace = SamtWorkspace(DiagnosticController("file:///tmp/test".toPathUri()))
+        val workspace = SamtFolder(DiagnosticController("file:///tmp/test".toPathUri()))
         val uri = "file:///tmp/test/model.samt".toPathUri()
         val fileInfo = parseFile(SourceFile(uri, "package foo.bar"))
         workspace.set(fileInfo)
@@ -46,7 +46,7 @@ class SamtWorkspaceTest {
 
     @Test
     fun `getFilesIn returns files in directory`() {
-        val workspace = SamtWorkspace(DiagnosticController("file:///tmp/test".toPathUri()))
+        val workspace = SamtFolder(DiagnosticController("file:///tmp/test".toPathUri()))
         val file1 = "file:///tmp/test/dir/foo.samt".toPathUri()
         val file2 = "file:///tmp/test/dir/bar.samt".toPathUri()
         val file3 = "file:///tmp/test/baz.samt".toPathUri()
@@ -61,7 +61,7 @@ class SamtWorkspaceTest {
 
     @Test
     fun `getMessages includes parser and semantic messages`() {
-        val workspace = SamtWorkspace(DiagnosticController("file:///tmp/test".toPathUri()))
+        val workspace = SamtFolder(DiagnosticController("file:///tmp/test".toPathUri()))
         val uri1 = "file:///tmp/test/record.samt".toPathUri()
         val uri2 = "file:///tmp/test/service.samt".toPathUri()
         val fileInfo1 = parseFile(SourceFile(uri1, "package foo.bar recrd Foo { "))
@@ -73,11 +73,11 @@ class SamtWorkspaceTest {
         assertEquals(2, messages.size)
     }
 
-    private fun createWorkspaces(): Map<URI, SamtWorkspace> {
+    private fun createWorkspaces(): Map<URI, SamtFolder> {
         val dir1 = "file:///foo/bar".toPathUri()
         val dir2 = "file:///foo/baz".toPathUri()
-        val workspace1 = SamtWorkspace(DiagnosticController(dir1))
-        val workspace2 = SamtWorkspace(DiagnosticController(dir2))
+        val workspace1 = SamtFolder(DiagnosticController(dir1))
+        val workspace2 = SamtFolder(DiagnosticController(dir2))
         return mapOf(
             dir1 to workspace1,
             dir2 to workspace2,

--- a/language-server/src/test/kotlin/tools/samt/ls/SamtFolderTest.kt
+++ b/language-server/src/test/kotlin/tools/samt/ls/SamtFolderTest.kt
@@ -1,29 +1,12 @@
 package tools.samt.ls
 
-import tools.samt.common.DiagnosticController
 import tools.samt.common.SourceFile
-import java.net.URI
 import kotlin.test.*
 
 class SamtFolderTest {
     @Test
-    fun `getByFile returns correct workspace`() {
-        val workspaces = createWorkspaces()
-        val workspace1 = assertNotNull(workspaces["file:///foo/bar".toPathUri()])
-        val workspace2 = assertNotNull(workspaces["file:///foo/baz".toPathUri()])
-        assertSame(workspace1, workspaces.getByFile("file:///foo/bar/greeter.samt".toPathUri()))
-        assertSame(workspace2, workspaces.getByFile("file:///foo/baz/greeter.samt".toPathUri()))
-    }
-
-    @Test
-    fun `getByFile returns null if file is outside of workspaces`() {
-        val workspaces = createWorkspaces()
-        assertNull(workspaces.getByFile("file:///foo/bars/greeter.samt".toPathUri()))
-    }
-
-    @Test
     fun `file can be retrieved with URI after set`() {
-        val workspace = SamtFolder(DiagnosticController("file:///tmp/test".toPathUri()))
+        val workspace = SamtFolder("file:///tmp/test".toPathUri())
         val uri = "file:///tmp/test/model.samt".toPathUri()
         val fileInfo = parseFile(SourceFile(uri, "package foo.bar"))
         workspace.set(fileInfo)
@@ -34,7 +17,7 @@ class SamtFolderTest {
 
     @Test
     fun `file cannot be retrieved after removal`() {
-        val workspace = SamtFolder(DiagnosticController("file:///tmp/test".toPathUri()))
+        val workspace = SamtFolder("file:///tmp/test".toPathUri())
         val uri = "file:///tmp/test/model.samt".toPathUri()
         val fileInfo = parseFile(SourceFile(uri, "package foo.bar"))
         workspace.set(fileInfo)
@@ -46,7 +29,7 @@ class SamtFolderTest {
 
     @Test
     fun `getFilesIn returns files in directory`() {
-        val workspace = SamtFolder(DiagnosticController("file:///tmp/test".toPathUri()))
+        val workspace = SamtFolder("file:///tmp/test".toPathUri())
         val file1 = "file:///tmp/test/dir/foo.samt".toPathUri()
         val file2 = "file:///tmp/test/dir/bar.samt".toPathUri()
         val file3 = "file:///tmp/test/baz.samt".toPathUri()
@@ -61,7 +44,7 @@ class SamtFolderTest {
 
     @Test
     fun `getMessages includes parser and semantic messages`() {
-        val workspace = SamtFolder(DiagnosticController("file:///tmp/test".toPathUri()))
+        val workspace = SamtFolder("file:///tmp/test".toPathUri())
         val uri1 = "file:///tmp/test/record.samt".toPathUri()
         val uri2 = "file:///tmp/test/service.samt".toPathUri()
         val fileInfo1 = parseFile(SourceFile(uri1, "package foo.bar recrd Foo { "))
@@ -71,16 +54,5 @@ class SamtFolderTest {
         workspace.buildSemanticModel()
         val messages = workspace.getAllMessages()
         assertEquals(2, messages.size)
-    }
-
-    private fun createWorkspaces(): Map<URI, SamtFolder> {
-        val dir1 = "file:///foo/bar".toPathUri()
-        val dir2 = "file:///foo/baz".toPathUri()
-        val workspace1 = SamtFolder(DiagnosticController(dir1))
-        val workspace2 = SamtFolder(DiagnosticController(dir2))
-        return mapOf(
-            dir1 to workspace1,
-            dir2 to workspace2,
-        )
     }
 }

--- a/language-server/src/test/kotlin/tools/samt/ls/SamtWorkspaceTest.kt
+++ b/language-server/src/test/kotlin/tools/samt/ls/SamtWorkspaceTest.kt
@@ -1,0 +1,28 @@
+package tools.samt.ls
+
+import tools.samt.common.DiagnosticController
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class SamtWorkspaceTest {
+    private val dir1 = "file:///foo/bar".toPathUri()
+    private val dir2 = "file:///foo/baz".toPathUri()
+    private val workspace1 = SamtWorkspace(DiagnosticController(dir1))
+    private val workspace2 = SamtWorkspace(DiagnosticController(dir2))
+    private val workspaces = mapOf(
+        dir1 to workspace1,
+        dir2 to workspace2,
+    )
+
+    @Test
+    fun `getByFile returns correct workspace`() {
+        assertSame(workspace1, workspaces.getByFile("file:///foo/bar/greeter.samt".toPathUri()))
+        assertSame(workspace2, workspaces.getByFile("file:///foo/baz/greeter.samt".toPathUri()))
+    }
+
+    @Test
+    fun `getByFile returns null if file is outside of workspaces`() {
+        assertNull(workspaces.getByFile("file:///foo/bars/greeter.samt".toPathUri()))
+    }
+}

--- a/language-server/src/test/kotlin/tools/samt/ls/SamtWorkspaceTest.kt
+++ b/language-server/src/test/kotlin/tools/samt/ls/SamtWorkspaceTest.kt
@@ -1,28 +1,86 @@
 package tools.samt.ls
 
 import tools.samt.common.DiagnosticController
-import kotlin.test.Test
-import kotlin.test.assertNull
-import kotlin.test.assertSame
+import tools.samt.common.SourceFile
+import java.net.URI
+import kotlin.test.*
 
 class SamtWorkspaceTest {
-    private val dir1 = "file:///foo/bar".toPathUri()
-    private val dir2 = "file:///foo/baz".toPathUri()
-    private val workspace1 = SamtWorkspace(DiagnosticController(dir1))
-    private val workspace2 = SamtWorkspace(DiagnosticController(dir2))
-    private val workspaces = mapOf(
-        dir1 to workspace1,
-        dir2 to workspace2,
-    )
-
     @Test
     fun `getByFile returns correct workspace`() {
+        val workspaces = createWorkspaces()
+        val workspace1 = assertNotNull(workspaces["file:///foo/bar".toPathUri()])
+        val workspace2 = assertNotNull(workspaces["file:///foo/baz".toPathUri()])
         assertSame(workspace1, workspaces.getByFile("file:///foo/bar/greeter.samt".toPathUri()))
         assertSame(workspace2, workspaces.getByFile("file:///foo/baz/greeter.samt".toPathUri()))
     }
 
     @Test
     fun `getByFile returns null if file is outside of workspaces`() {
+        val workspaces = createWorkspaces()
         assertNull(workspaces.getByFile("file:///foo/bars/greeter.samt".toPathUri()))
+    }
+
+    @Test
+    fun `file can be retrieved with URI after set`() {
+        val workspace = SamtWorkspace(DiagnosticController("file:///tmp/test".toPathUri()))
+        val uri = "file:///tmp/test/model.samt".toPathUri()
+        val fileInfo = parseFile(SourceFile(uri, "package foo.bar"))
+        workspace.set(fileInfo)
+        assertSame(fileInfo, workspace[uri])
+        assertTrue(uri in workspace)
+        assertContains(workspace as Iterable<FileInfo>, fileInfo)
+    }
+
+    @Test
+    fun `file cannot be retrieved after removal`() {
+        val workspace = SamtWorkspace(DiagnosticController("file:///tmp/test".toPathUri()))
+        val uri = "file:///tmp/test/model.samt".toPathUri()
+        val fileInfo = parseFile(SourceFile(uri, "package foo.bar"))
+        workspace.set(fileInfo)
+        workspace.remove(uri)
+        assertNull(workspace[uri])
+        assertFalse(uri in workspace)
+        assertFalse(fileInfo in workspace)
+    }
+
+    @Test
+    fun `getFilesIn returns files in directory`() {
+        val workspace = SamtWorkspace(DiagnosticController("file:///tmp/test".toPathUri()))
+        val file1 = "file:///tmp/test/dir/foo.samt".toPathUri()
+        val file2 = "file:///tmp/test/dir/bar.samt".toPathUri()
+        val file3 = "file:///tmp/test/baz.samt".toPathUri()
+        val fileInfo1 = parseFile(SourceFile(file1, "package foo.bar"))
+        val fileInfo2 = parseFile(SourceFile(file2, "package foo.bar"))
+        val fileInfo3 = parseFile(SourceFile(file3, "package foo.bar"))
+        workspace.set(fileInfo1)
+        workspace.set(fileInfo2)
+        workspace.set(fileInfo3)
+        assertEquals(setOf(file1, file2), workspace.getFilesIn("file:///tmp/test/dir".toPathUri()).toSet())
+    }
+
+    @Test
+    fun `getMessages includes parser and semantic messages`() {
+        val workspace = SamtWorkspace(DiagnosticController("file:///tmp/test".toPathUri()))
+        val uri1 = "file:///tmp/test/record.samt".toPathUri()
+        val uri2 = "file:///tmp/test/service.samt".toPathUri()
+        val fileInfo1 = parseFile(SourceFile(uri1, "package foo.bar recrd Foo { "))
+        val fileInfo2 = parseFile(SourceFile(uri2, "package foo.bar service FooService { getService(): Foo }"))
+        workspace.set(fileInfo1)
+        workspace.set(fileInfo2)
+        workspace.buildSemanticModel()
+        val messages = workspace.getAllMessages()
+        assertEquals(2, messages.size)
+    }
+
+    private fun createWorkspaces(): Map<URI, SamtWorkspace> {
+        val dir1 = "file:///foo/bar".toPathUri()
+        val dir2 = "file:///foo/baz".toPathUri()
+        val workspace1 = SamtWorkspace(DiagnosticController(dir1))
+        val workspace2 = SamtWorkspace(DiagnosticController(dir2))
+        return mapOf(
+            dir1 to workspace1,
+            dir2 to workspace2,
+        )
     }
 }

--- a/language-server/src/test/kotlin/tools/samt/ls/SamtWorkspaceTest.kt
+++ b/language-server/src/test/kotlin/tools/samt/ls/SamtWorkspaceTest.kt
@@ -1,0 +1,146 @@
+package tools.samt.ls
+
+import tools.samt.common.DiagnosticSeverity
+import tools.samt.common.SourceFile
+import kotlin.test.*
+
+class SamtWorkspaceTest {
+    @Test
+    fun `getFile retrieves file`() {
+        val folder = SamtFolder("file:///tmp/test".toPathUri())
+        val workspace = SamtWorkspace()
+        val uri = "file:///tmp/test/model.samt".toPathUri()
+        workspace.addFolder(folder)
+        val fileInfo = parseFile(SourceFile (uri, "package foo.bar"))
+        folder.set(fileInfo)
+        assertSame(fileInfo, workspace.getFile(uri))
+    }
+
+    @Test
+    fun `file is in folder snapshot`() {
+        val folder = SamtFolder("file:///tmp/test".toPathUri())
+        val workspace = SamtWorkspace()
+        val uri = "file:///tmp/test/model.samt".toPathUri()
+        workspace.addFolder(folder)
+        val fileInfo = parseFile(SourceFile (uri, "package foo.bar"))
+        folder.set(fileInfo)
+        val snapshot = workspace.getFolderSnapshot("file:///tmp/test".toPathUri())
+        assertEquals(listOf(fileInfo), snapshot?.files)
+    }
+
+    @Test
+    fun `folder which is already contained in other folder is ignored`() {
+        val outer = SamtFolder("file:///tmp/test".toPathUri())
+        val inner = SamtFolder("file:///tmp/test/inner".toPathUri())
+        val workspace = SamtWorkspace()
+        workspace.addFolder(outer)
+        workspace.addFolder(inner)
+        val snapshot = workspace.getFolderSnapshot("file:///tmp/test/inner".toPathUri())
+        assertEquals(outer.path, snapshot?.path)
+    }
+
+    @Test
+    fun `folder which contains other folder overwrites it`() {
+        val inner = SamtFolder("file:///tmp/test/inner".toPathUri())
+        val outer = SamtFolder("file:///tmp/test".toPathUri())
+        val workspace = SamtWorkspace()
+        workspace.addFolder(inner)
+        workspace.addFolder(outer)
+        val snapshot = workspace.getFolderSnapshot("file:///tmp/test/inner".toPathUri())
+        assertEquals(outer.path, snapshot?.path)
+    }
+
+    @Test
+    fun `getPendingMessages includes messages from new files`() {
+        val workspace = SamtWorkspace()
+        workspace.addFolder(SamtFolder("file:///tmp/test".toPathUri()))
+        val uri = "file:///tmp/test/model.samt".toPathUri()
+        val fileInfo = parseFile(SourceFile (uri, "package foo.bar record Foo {"))
+        workspace.setFile(fileInfo)
+        val messages = workspace.getPendingMessages()[uri]
+        assertEquals(DiagnosticSeverity.Error, messages?.single()?.severity)
+    }
+
+    @Test
+    fun `getPendingMessages includes emptyList for removed file`() {
+        val workspace = SamtWorkspace()
+        workspace.addFolder(SamtFolder("file:///tmp/test".toPathUri()))
+        val uri = "file:///tmp/test/model.samt".toPathUri()
+        val fileInfo = parseFile(SourceFile (uri, "package foo.bar record Foo {"))
+        workspace.setFile(fileInfo)
+        workspace.removeFile(uri)
+        val messages = workspace.getPendingMessages()
+        assertEquals(mapOf(uri to emptyList()), messages)
+    }
+
+    @Test
+    fun `getPendingMessages includes empty list for every file in removed folder`() {
+        val workspace = SamtWorkspace()
+        workspace.addFolder(SamtFolder("file:///tmp/test".toPathUri()))
+        val file1 = parseFile(SourceFile ("file:///tmp/test/foo.samt".toPathUri(), "package foo.bar record Foo {"))
+        val file2 = parseFile(SourceFile ("file:///tmp/test/bar.samt".toPathUri(), "package foo.bar record Bar {"))
+        workspace.setFile(file1)
+        workspace.setFile(file2)
+        workspace.removeFolder("file:///tmp/test".toPathUri())
+        val messages = workspace.getPendingMessages()
+        assertEquals(mapOf(file1.path to emptyList(), file2.path to emptyList()), messages)
+    }
+
+    @Test
+    fun `getPendingMessages is empty after clearing changes`() {
+        val workspace = SamtWorkspace()
+        workspace.addFolder(SamtFolder("file:///tmp/test".toPathUri()))
+        val uri = "file:///tmp/test/model.samt".toPathUri()
+        val fileInfo = parseFile(SourceFile (uri, "package foo.bar record Foo {"))
+        workspace.setFile(fileInfo)
+        workspace.clearChanges()
+        val messages = workspace.getPendingMessages()
+        assertEquals(emptyMap(), messages)
+    }
+
+    @Test
+    fun `removing file triggers semantic error in dependent file`() {
+        val workspace = SamtWorkspace()
+        workspace.addFolder(SamtFolder("file:///tmp/test".toPathUri()))
+        val file1 = parseFile(SourceFile ("file:///tmp/test/foo.samt".toPathUri(), "package foo.bar record Foo {}"))
+        val file2 = parseFile(SourceFile ("file:///tmp/test/bar.samt".toPathUri(), "package foo.bar record Bar { foo: Foo }"))
+        workspace.setFile(file1)
+        workspace.setFile(file2)
+        workspace.buildSemanticModel()
+        val messagesBefore = workspace.getPendingMessages()
+        assertEquals(mapOf(file1.path to emptyList(), file2.path to emptyList()), messagesBefore)
+        workspace.removeFile(file1.path)
+        workspace.buildSemanticModel()
+        val messagesAfter = workspace.getPendingMessages()
+        assertEquals(emptyList(), messagesAfter[file1.path])
+        assertNotNull(messagesAfter[file2.path]).single().let {
+            assertEquals(DiagnosticSeverity.Error, it.severity)
+            assertEquals("Type 'Foo' could not be resolved", it.message)
+        }
+    }
+
+    @Test
+    fun `getPendingMessages includes empty list for every file in removed directory`() {
+        val workspace = SamtWorkspace()
+        workspace.addFolder(SamtFolder("file:///tmp/test".toPathUri()))
+        val file1 = parseFile(SourceFile ("file:///tmp/test/subfolder/foo.samt".toPathUri(), "package foo.bar record Foo {"))
+        val file2 = parseFile(SourceFile ("file:///tmp/test/subfolder/bar.samt".toPathUri(), "package foo.bar record Bar {"))
+        workspace.setFile(file1)
+        workspace.setFile(file2)
+        workspace.removeDirectory("file:///tmp/test/subfolder".toPathUri())
+        val messages = workspace.getPendingMessages()
+        assertEquals(mapOf(file1.path to emptyList(), file2.path to emptyList()), messages)
+    }
+
+    @Test
+    fun `package can be found after buildSemanticModel`() {
+        val workspace = SamtWorkspace()
+        workspace.addFolder(SamtFolder("file:///tmp/test".toPathUri()))
+        val file1 = parseFile(SourceFile ("file:///tmp/test/foo.samt".toPathUri(), "package foo.bar record Foo {}"))
+        workspace.setFile(file1)
+        assertNull(workspace.getRootPackage(file1.path))
+        workspace.buildSemanticModel()
+        val rootPackage = workspace.getRootPackage(file1.path)
+        assertNotNull(rootPackage)
+    }
+}

--- a/language-server/src/test/kotlin/tools/samt/ls/SamtWorkspaceTest.kt
+++ b/language-server/src/test/kotlin/tools/samt/ls/SamtWorkspaceTest.kt
@@ -143,4 +143,16 @@ class SamtWorkspaceTest {
         val rootPackage = workspace.getRootPackage(file1.path)
         assertNotNull(rootPackage)
     }
+
+    @Test
+    fun `if file has not changed pending messages don't change`() {
+        val workspace = SamtWorkspace()
+        workspace.addFolder(SamtFolder("file:///tmp/test".toPathUri()))
+        val sourceFile = SourceFile("file:///tmp/test/foo.samt".toPathUri(), "package foo.bar record Foo {")
+        workspace.setFile(parseFile(sourceFile))
+        assertEquals(1, workspace.getPendingMessages().size)
+        workspace.clearChanges()
+        workspace.setFile(parseFile(sourceFile))
+        assertEquals(emptyMap(), workspace.getPendingMessages())
+    }
 }

--- a/language-server/src/test/kotlin/tools/samt/ls/UriTest.kt
+++ b/language-server/src/test/kotlin/tools/samt/ls/UriTest.kt
@@ -2,10 +2,26 @@ package tools.samt.ls
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class UriTest {
     @Test
     fun `correctly transforms encoded URIs`() {
         assertEquals("file:///c:/test/directory", "file:///c%3A/test/directory".toPathUri().toString())
+    }
+
+    @Test
+    fun `startsWith returns true if URI is contained in folder`() {
+        assertTrue("file:///c:/test/directory".toPathUri().startsWith("file:///c:/test".toPathUri()))
+    }
+
+    @Test
+    fun `startsWith returns false if URI is just a prefix`() {
+        assertTrue(!"file:///c:/testtest".toPathUri().startsWith("file:///c:/test".toPathUri()))
+    }
+
+    @Test
+    fun `startsWith returns true if URIs are identical`() {
+        assertTrue("file:///c:/test".toPathUri().startsWith("file:///c:/test".toPathUri()))
     }
 }

--- a/language-server/src/test/kotlin/tools/samt/ls/UriTest.kt
+++ b/language-server/src/test/kotlin/tools/samt/ls/UriTest.kt
@@ -2,6 +2,7 @@ package tools.samt.ls
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class UriTest {
@@ -17,7 +18,7 @@ class UriTest {
 
     @Test
     fun `startsWith returns false if URI is just a prefix`() {
-        assertTrue(!"file:///c:/testtest".toPathUri().startsWith("file:///c:/test".toPathUri()))
+        assertFalse("file:///c:/testtest".toPathUri().startsWith("file:///c:/test".toPathUri()))
     }
 
     @Test

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ dependencyResolutionManagement {
         val jCommander = "1.82"
         val mordant = "2.0.0-beta13"
         val kotlinxSerialization = "1.5.0"
-        val kover = "0.7.0-Beta"
+        val kover = "0.7.0"
         val lsp4j = "0.20.1"
 
         create("libs") {


### PR DESCRIPTION
- feat(ls): extract repeated workspace logic
- feat(ls): react to changes on file system
- feat(ls): rename SamtWorkspace::add to set
- test(ls): add test for getByFile
- feat(ls): add workingDirectory property to SamtWorkspace
- feat(ls): read closed files from disk
- feat(ls): handle file rename, creation and deletion
- feat(ls): editor state when file is opened
