### PR TITLE
Warn when providers and consumers are not in their own files

### DIFF
--- a/semantic/src/main/kotlin/tools/samt/semantic/SemanticModelPreProcessor.kt
+++ b/semantic/src/main/kotlin/tools/samt/semantic/SemanticModelPreProcessor.kt
@@ -43,7 +43,7 @@ internal class SemanticModelPreProcessor(private val controller: DiagnosticContr
 
     private fun reportFileSeparation(file: FileNode) {
         val statements = file.statements
-        if (statements.size <= 1) {
+        if (statements.size < 10) {
             return
         }
         for (provider in statements.filterIsInstance<ProviderDeclarationNode>()) {

--- a/semantic/src/main/kotlin/tools/samt/semantic/SemanticModelPreProcessor.kt
+++ b/semantic/src/main/kotlin/tools/samt/semantic/SemanticModelPreProcessor.kt
@@ -41,8 +41,29 @@ internal class SemanticModelPreProcessor(private val controller: DiagnosticContr
         }
     }
 
+    private fun reportFileSeparation(file: FileNode) {
+        val statements = file.statements
+        if (statements.size <= 1) {
+            return
+        }
+        for (provider in statements.filterIsInstance<ProviderDeclarationNode>()) {
+            controller.getOrCreateContext(provider.location.source).warn {
+                message("Provider declaration should be in its own file")
+                highlight("provider declaration", provider.location, highlightBeginningOnly = true)
+            }
+        }
+        for (consumer in statements.filterIsInstance<ConsumerDeclarationNode>()) {
+            controller.getOrCreateContext(consumer.location.source).warn {
+                message("Consumer declaration should be in its own file")
+                highlight("consumer declaration", consumer.location, highlightBeginningOnly = true)
+            }
+        }
+    }
+
     fun fillPackage(samtPackage: Package, files: List<FileNode>) {
         for (file in files) {
+            reportFileSeparation(file)
+
             var parentPackage = samtPackage
             for (component in file.packageDeclaration.name.components) {
                 var subPackage = parentPackage.subPackages.find { it.name == component.name }

--- a/semantic/src/test/kotlin/tools/samt/semantic/SemanticModelTest.kt
+++ b/semantic/src/test/kotlin/tools/samt/semantic/SemanticModelTest.kt
@@ -1251,6 +1251,16 @@ class SemanticModelTest {
             val source = """
                 package separation
                 
+                record A {}
+                record B {}
+                record C {}
+                record D {}
+                record E {}
+                record F {}
+                record G {}
+                record H {}
+                record I {}
+                
                 service TestService {}
                 
                 provide TestProvider {
@@ -1268,6 +1278,16 @@ class SemanticModelTest {
         fun `consumer in file with other types is warning`() {
             val source = """
                 package separation
+                
+                record A {}
+                record B {}
+                record C {}
+                record D {}
+                record E {}
+                record F {}
+                record G {}
+                record H {}
+                record I {}
                 
                 service TestService {}
                 

--- a/semantic/src/test/kotlin/tools/samt/semantic/SemanticModelTest.kt
+++ b/semantic/src/test/kotlin/tools/samt/semantic/SemanticModelTest.kt
@@ -1244,6 +1244,54 @@ class SemanticModelTest {
         }
     }
 
+    @Nested
+    inner class FileSeparation {
+        @Test
+        fun `provider in file with other types is warning`()  {
+            val source = """
+                package separation
+                
+                service TestService {}
+                
+                provide TestProvider {
+                    implements TestService
+                
+                    transport http
+                }
+            """.trimIndent()
+            parseAndCheck(
+                source to listOf("Warning: Provider declaration should be in its own file")
+            )
+        }
+
+        @Test
+        fun `consumer in file with other types is warning`() {
+            val source = """
+                package separation
+                
+                service TestService {}
+                
+                consume TestProvider {
+                    uses TestService
+                }
+            """.trimIndent()
+            val providerSource = """
+                package separation
+                
+                provide TestProvider {
+                    implements TestService
+                
+                    transport http
+                }
+            """.trimIndent()
+
+            parseAndCheck(
+                source to listOf("Warning: Consumer declaration should be in its own file"),
+                providerSource to emptyList()
+            )
+        }
+    }
+
     private fun parseAndCheck(
         vararg sourceAndExpectedMessages: Pair<String, List<String>>,
     ): SemanticModel {


### PR DESCRIPTION
- feat(semantic): add warning when providers and consumers are not in their own files
- feat(semantic): only warn if there are more than ten statements in a file

Not sure about the threshold criteria, currently it's just the number of top level statements, but perhaps the complexity of the declared services should also play a role. This implementation will also warn if there are multiple providers or multiple consumers in one file.